### PR TITLE
updates '/' route to handle keyError

### DIFF
--- a/python-flask-sso-example/app.py
+++ b/python-flask-sso-example/app.py
@@ -27,7 +27,7 @@ def to_pretty_json(value):
 
 app.jinja_env.filters["tojson_pretty"] = to_pretty_json
 
-
+@app.route("/")
 def login():
     try:
         return render_template(

--- a/python-flask-sso-example/app.py
+++ b/python-flask-sso-example/app.py
@@ -28,15 +28,14 @@ def to_pretty_json(value):
 app.jinja_env.filters["tojson_pretty"] = to_pretty_json
 
 
-@app.route("/")
 def login():
-    if session["raw_profile"]:
+    try:
         return render_template(
             "login_successful.html",
             first_name=session["first_name"],
             raw_profile=session["raw_profile"],
         )
-    else:
+    except KeyError:
         return render_template("login.html")
 
 


### PR DESCRIPTION
Right now, if you haven't used the application, the, if condition to check session["raw_profile"], throws a keyError as the session key doesn't exist yet.  Setting it to a try with an except should handle this